### PR TITLE
fix: Update scorecard-action to use specific version v2.4.3

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -24,7 +24,7 @@ jobs:
           persist-credentials: false
 
       - name: Run analysis
-        uses: ossf/scorecard-action@v2
+        uses: ossf/scorecard-action@v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
## Summary
- Fixed OpenSSF Scorecard workflow that was failing because `@v2` is not a valid version tag
- Updated to use the latest stable version `v2.4.3`

## Test plan
- Workflow should now run successfully on the next push to main
- The scorecard analysis will complete and upload results

## References
- Fixes: https://github.com/amulya-labs/gha-opencache/actions/runs/21887305906
- Error: "Unable to resolve action `ossf/scorecard-action@v2`, unable to find version `v2`"

🤖 Generated with [Claude Code](https://claude.com/claude-code)