### PR TITLE
fix(docs): Use --force for release tag updates

### DIFF
--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -72,9 +72,8 @@ git checkout -b hotfix/description vX.Y.Z
 
 **Tag already exists:**
 ```bash
-git tag -d vX.Y.Z
-git push origin :refs/tags/vX.Y.Z
-# Then recreate
+git tag -f vX.Y.Z
+git push --force origin vX.Y.Z
 ```
 
 **Delete a release:**


### PR DESCRIPTION
## Summary
The delete-then-push pattern for updating floating major tags failed silently during the v1.2.0 release. Using `--force` is simpler and more reliable.

**Before (4 lines, error-prone):**
```bash
git tag -d v${MAJOR_VERSION} 2>/dev/null
git push origin :refs/tags/v${MAJOR_VERSION} 2>/dev/null
git tag v${MAJOR_VERSION} v${NEW_VERSION}
git push origin v${MAJOR_VERSION}
```

**After (2 lines, reliable):**
```bash
git tag -f v${MAJOR_VERSION} v${NEW_VERSION}
git push --force origin v${MAJOR_VERSION}
```

## Test plan
- [x] Discovered during v1.2.0 release when remote tag deletion silently failed

🤖 Generated with [Claude Code](https://claude.ai/code)