### PR TITLE
fix: Use PAT for major tag update to bypass tag protection

### DIFF
--- a/.github/workflows/update-major-tag.yml
+++ b/.github/workflows/update-major-tag.yml
@@ -13,6 +13,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.ref }}
+          token: ${{ secrets.PUBLIC_REPO_WRITE_PAT }}
       - name: Update major version tag
         run: |
           VERSION=${GITHUB_REF_NAME}  # e.g., v1.2.1


### PR DESCRIPTION
## Summary
- Use a PAT (`PUBLIC_REPO_WRITE_PAT` secret) instead of the default `GITHUB_TOKEN` for pushing the major version tag
- Fixes the tag protection rule violation: `GH013: Repository rule violations found for refs/tags/v1`

## Test plan
- [x] Add `PUBLIC_REPO_WRITE_PAT` secret to repository
- [ ] Create a test release (e.g., v1.3.1)
- [ ] Verify workflow succeeds and `v1` tag is updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)