### PR TITLE
docs: Update RELEASING.md for v3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,19 @@
 name: Release with SLSA Provenance
 
+# =============================================================================
+# FLOATING TAG PROTECTION
+# =============================================================================
+# This workflow triggers on ALL v* tags, including floating major tags (v3).
+# When update-major-tag pushes v3, it triggers a new workflow run.
+#
+# CRITICAL: Jobs that create GitHub Releases or publish packages MUST have:
+#   if: ${{ contains(github.ref_name, '.') }}
+# This ensures they only run for semver tags (v3.0.0) not floating tags (v3).
+#
+# GitHub Releases lock their associated tags (immutable: true), which would
+# permanently corrupt floating tags. See docs/RELEASING.md for details.
+# =============================================================================
+
 on:
   push:
     tags:
@@ -14,6 +28,8 @@ jobs:
   build-artifacts:
     name: Build Release Artifacts
     runs-on: ubuntu-latest
+    # Only build for semver tags (v3.0.0), skip floating tags (v3) to save CI minutes
+    if: ${{ contains(github.ref_name, '.') }}
     outputs:
       hashes: ${{ steps.hash.outputs.hashes }}
     steps:

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -4,7 +4,7 @@ Migration from `actions/cache` and storage backend setup.
 
 ## From actions/cache
 
-**Two steps:** (1) Change `uses: actions/cache@v4` → `amulya-labs/gha-opencache@v2` | (2) Choose storage (see below)
+**Two steps:** (1) Change `uses: actions/cache@v4` → `amulya-labs/gha-opencache@v3` | (2) Choose storage (see below)
 
 All inputs, outputs, and behavior are identical.
 
@@ -62,7 +62,7 @@ find ~/.cache/gha-opencache -type f -mtime +7 -delete
 
 **Common workflow config:**
 ```yaml
-- uses: amulya-labs/gha-opencache@v2
+- uses: amulya-labs/gha-opencache@v3
   with:
     storage-provider: s3
     s3-bucket: my-cache-bucket
@@ -165,7 +165,7 @@ gcloud iam service-accounts keys create gha-cache-key.json \
     echo '${{ secrets.GCP_SA_KEY }}' > ${{ runner.temp }}/gcp-key.json
     echo "GOOGLE_APPLICATION_CREDENTIALS=${{ runner.temp }}/gcp-key.json" >> $GITHUB_ENV
 
-- uses: amulya-labs/gha-opencache@v2
+- uses: amulya-labs/gha-opencache@v3
   with:
     storage-provider: gcs
     gcs-bucket: my-gha-cache-bucket
@@ -212,7 +212,7 @@ jobs:
         with:
           workload_identity_provider: projects/PROJECT_NUMBER/locations/global/workloadIdentityPools/github-pool/providers/github-provider
           service_account: github-actions-cache@my-project.iam.gserviceaccount.com
-      - uses: amulya-labs/gha-opencache@v2
+      - uses: amulya-labs/gha-opencache@v3
         with:
           storage-provider: gcs
           gcs-bucket: my-gha-cache-bucket

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@
 ## Quick Start
 
 ```yaml
-- uses: amulya-labs/gha-opencache@v2
+- uses: amulya-labs/gha-opencache@v3
   with:
     path: node_modules
     key: npm-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
@@ -55,7 +55,7 @@
 **S3-compatible** (MinIO, R2, AWS S3, etc.):
 
 ```yaml
-- uses: amulya-labs/gha-opencache@v2
+- uses: amulya-labs/gha-opencache@v3
   with:
     path: node_modules
     key: npm-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
@@ -71,7 +71,7 @@
 **Google Cloud Storage**:
 
 ```yaml
-- uses: amulya-labs/gha-opencache@v2
+- uses: amulya-labs/gha-opencache@v3
   with:
     path: node_modules
     key: npm-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
@@ -321,7 +321,7 @@ jobs:
       volumes:
         - /srv/gha-cache:/cache
     steps:
-      - uses: amulya-labs/gha-opencache@v2
+      - uses: amulya-labs/gha-opencache@v3
         with:
           cache-path: /cache
 ```

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -16,7 +16,7 @@ jobs:
         - /srv/gha-cache:/srv/gha-cache  # Mount a volume
 
     steps:
-      - uses: amulya-labs/gha-opencache@v2
+      - uses: amulya-labs/gha-opencache@v3
         with:
           path: .venv
           key: deps-${{ hashFiles('**/requirements.txt') }}
@@ -68,7 +68,7 @@ jobs:
       - uses: actions/checkout@v4
       
       - name: Cache node_modules
-        uses: amulya-labs/gha-opencache@v2
+        uses: amulya-labs/gha-opencache@v3
         with:
           path: node_modules
           key: npm-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
@@ -97,21 +97,21 @@ jobs:
 
       # All caches use the same cache-path
       - name: Cache Python dependencies
-        uses: amulya-labs/gha-opencache@v2
+        uses: amulya-labs/gha-opencache@v3
         with:
           path: .venv
           key: poetry-${{ hashFiles('poetry.lock') }}
           cache-path: /srv/gha-cache
 
       - name: Cache Ruff
-        uses: amulya-labs/gha-opencache@v2
+        uses: amulya-labs/gha-opencache@v3
         with:
           path: .ruff_cache
           key: ruff-${{ hashFiles('src/**/*.py') }}
           cache-path: /srv/gha-cache
 
       - name: Cache pytest
-        uses: amulya-labs/gha-opencache@v2
+        uses: amulya-labs/gha-opencache@v3
         with:
           path: .pytest_cache
           key: pytest-${{ hashFiles('tests/**/*.py') }}
@@ -135,7 +135,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Cache Gradle
-        uses: amulya-labs/gha-opencache@v2
+        uses: amulya-labs/gha-opencache@v3
         with:
           path: ~/.gradle/caches
           key: gradle-${{ hashFiles('**/*.gradle*') }}
@@ -159,7 +159,7 @@ If you're upgrading from `gha-opencache@v1` and use containers, you **must** add
 ### After (v2 - requires explicit cache-path)
 
 ```yaml
-- uses: amulya-labs/gha-opencache@v2
+- uses: amulya-labs/gha-opencache@v3
   with:
     path: .venv
     key: deps-${{ hashFiles('poetry.lock') }}
@@ -191,7 +191,7 @@ the container and will not persist between jobs.
 
 To fix, add an explicit cache-path with a mounted volume:
 
-  - uses: amulya-labs/gha-opencache@v2
+  - uses: amulya-labs/gha-opencache@v3
     with:
       cache-path: /srv/gha-cache
 
@@ -239,14 +239,14 @@ Otherwise, verify:
 
 ```yaml
 # Before (broken)
-- uses: amulya-labs/gha-opencache@v2
+- uses: amulya-labs/gha-opencache@v3
   with:
     path: .venv
     key: deps-${{ hashFiles('poetry.lock') }}
     # Missing cache-path!
 
 # After (fixed)
-- uses: amulya-labs/gha-opencache@v2
+- uses: amulya-labs/gha-opencache@v3
   with:
     path: .venv
     key: deps-${{ hashFiles('poetry.lock') }}
@@ -284,7 +284,7 @@ container:
     #   Host path      Container path
     
 steps:
-  - uses: amulya-labs/gha-opencache@v2
+  - uses: amulya-labs/gha-opencache@v3
     with:
       cache-path: /srv/gha-cache  # ← Must match container path
 ```
@@ -322,7 +322,7 @@ jobs:
       volumes:
         - /srv/gha-cache:/srv/gha-cache
     steps:
-      - uses: amulya-labs/gha-opencache@v2
+      - uses: amulya-labs/gha-opencache@v3
         with:
           cache-path: /srv/gha-cache
 
@@ -331,7 +331,7 @@ jobs:
       volumes:
         - /srv/gha-cache:/srv/gha-cache
     steps:
-      - uses: amulya-labs/gha-opencache@v2
+      - uses: amulya-labs/gha-opencache@v3
         with:
           cache-path: /srv/gha-cache
 ```
@@ -344,7 +344,7 @@ Add comments explaining the container requirement:
 - name: Cache dependencies
   # NOTE: cache-path required for container-based jobs
   # Without it, v2 uses $HOME/.cache/gha-opencache (ephemeral)
-  uses: amulya-labs/gha-opencache@v2
+  uses: amulya-labs/gha-opencache@v3
   with:
     path: node_modules
     cache-path: /srv/gha-cache  # Use mounted volume (persists across runs)
@@ -372,7 +372,7 @@ jobs:
       volumes:
         - ${{ env.CACHE_PATH }}:${{ env.CACHE_PATH }}
     steps:
-      - uses: amulya-labs/gha-opencache@v2
+      - uses: amulya-labs/gha-opencache@v3
         with:
           cache-path: ${{ env.CACHE_PATH }}
 ```
@@ -386,7 +386,7 @@ jobs:
   test:
     runs-on: ubuntu-latest  # No container
     steps:
-      - uses: amulya-labs/gha-opencache@v2
+      - uses: amulya-labs/gha-opencache@v3
         with:
           path: .venv
           key: deps-${{ hashFiles('poetry.lock') }}

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -156,7 +156,7 @@ If you're upgrading from `gha-opencache@v1` and use containers, you **must** add
     # No cache-path needed - v1 defaulted to /srv/gha-cache
 ```
 
-### After (v2 - requires explicit cache-path)
+### After (v2+ - requires explicit cache-path)
 
 ```yaml
 - uses: amulya-labs/gha-opencache@v3

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -19,7 +19,7 @@ After this initial setup, all subsequent releases via `gh release create` will a
 ```bash
 # === RELEASE SCRIPT ===
 # Update this variable for your release
-NEW_VERSION="2.0.0"
+NEW_VERSION="3.0.0"
 ```
 
 #### Create Release
@@ -54,7 +54,7 @@ When you push a version tag, the **release workflow** automatically:
 2. **provenance** - Generates SLSA Level 3 attestation
 3. **upload-assets** - Creates a draft release, uploads artifacts, then publishes
 4. **publish-package** - Publishes to GitHub Packages (npm, stable releases only)
-5. **update-major-tag** - Updates floating tag (e.g., `v2` → `v2.2.3`)
+5. **update-major-tag** - Updates floating tag (e.g., `v3` → `v3.0.1`)
 
 **Generated Artifacts:**
 - Source tarball (`gha-opencache-vX.Y.Z.tar.gz`)
@@ -62,15 +62,25 @@ When you push a version tag, the **release workflow** automatically:
 - SHA256 checksums (`checksums.txt`)
 - **SLSA provenance** (`*.intoto.jsonl`) - 10/10 OpenSSF score
 
-Users referencing `@v2` automatically get the latest compatible version. The entire release process completes in ~2-3 minutes.
+Users referencing `@v3` automatically get the latest compatible version. The entire release process completes in ~2-3 minutes.
+
+> **⚠️ Critical: Never Create Releases for Floating Tags**
+>
+> GitHub Releases lock their associated tags (`immutable: true`). If a release is created for a floating tag like `v3`, that tag becomes **permanently locked** and cannot be updated or deleted.
+>
+> The workflow has guards (`if: contains(github.ref_name, '.')`) to prevent this, but manual release creation can still cause corruption:
+> - **Wrong:** `gh release create v3 ...`
+> - **Right:** `gh release create v3.0.0 ...`
+>
+> If a floating tag gets corrupted, the only recovery is to increment the major version (e.g., v2 → v3).
 
 ## Versioning
 
-- **MAJOR** (`v2.0.0`): Breaking changes
-- **MINOR** (`v2.1.0`): New features, backward compatible
-- **PATCH** (`v2.0.1`): Bug fixes
+- **MAJOR** (`v3.0.0`): Breaking changes
+- **MINOR** (`v3.1.0`): New features, backward compatible
+- **PATCH** (`v3.0.1`): Bug fixes
 
-Users reference `@v2` (floating tag) to get compatible updates automatically.
+Users reference `@v3` (floating tag) to get compatible updates automatically.
 
 ## Choosing a Version
 
@@ -103,13 +113,6 @@ The workflow triggers on tag push (`v*`). Jobs run in parallel where possible, w
 
 **GitHub Packages Publishing:**
 The `publish-package` job modifies `package.json` at publish-time to configure the scoped package name and registry. This is intentional to keep the source `package.json` clean and avoid registry-specific configuration in the repository. The published package metadata will differ from the source repository.
-
-### Important: Never Create Releases for Major Tags
-
-GitHub Releases protect their associated tags from being updated. Only create releases for semver tags (`v2.0.0`), never for floating major tags (`v2`).
-
-**Wrong:** `gh release create v2 ...`
-**Right:** `gh release create v2.0.0 ...`
 
 ### Emergency Hotfix
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -76,9 +76,9 @@ Users referencing `@v3` automatically get the latest compatible version. The ent
 
 ## Versioning
 
-- **MAJOR** (`v3.0.0`): Breaking changes
-- **MINOR** (`v3.1.0`): New features, backward compatible
-- **PATCH** (`v3.0.1`): Bug fixes
+- **MAJOR** (`vX.0.0`): Breaking changes
+- **MINOR** (`vX.1.0`): New features, backward compatible
+- **PATCH** (`vX.0.1`): Bug fixes
 
 Users reference `@v3` (floating tag) to get compatible updates automatically.
 

--- a/examples/compression-tuning.yml
+++ b/examples/compression-tuning.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Cache with auto compression
-        uses: amulya-labs/gha-opencache@v2
+        uses: amulya-labs/gha-opencache@v3
         with:
           path: node_modules
           key: auto-${{ hashFiles('package-lock.json') }}
@@ -44,7 +44,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Cache with maximum compression
-        uses: amulya-labs/gha-opencache@v2
+        uses: amulya-labs/gha-opencache@v3
         with:
           path: node_modules
           key: max-${{ hashFiles('package-lock.json') }}
@@ -61,7 +61,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Cache with fast compression
-        uses: amulya-labs/gha-opencache@v2
+        uses: amulya-labs/gha-opencache@v3
         with:
           path: |
             node_modules
@@ -80,7 +80,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Cache without compression
-        uses: amulya-labs/gha-opencache@v2
+        uses: amulya-labs/gha-opencache@v3
         with:
           path: dist
           key: dist-${{ github.sha }}
@@ -96,7 +96,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Cache with gzip
-        uses: amulya-labs/gha-opencache@v2
+        uses: amulya-labs/gha-opencache@v3
         with:
           path: ~/.cargo
           key: cargo-${{ hashFiles('Cargo.lock') }}

--- a/examples/docker-containers.yml
+++ b/examples/docker-containers.yml
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Cache npm dependencies
-        uses: amulya-labs/gha-opencache@v2
+        uses: amulya-labs/gha-opencache@v3
         with:
           path: node_modules
           key: npm-container-${{ hashFiles('package-lock.json') }}
@@ -75,7 +75,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Cache node_modules
-        uses: amulya-labs/gha-opencache@v2
+        uses: amulya-labs/gha-opencache@v3
         with:
           path: node_modules
           key: deps-integration-${{ hashFiles('package-lock.json') }}
@@ -99,7 +99,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Cache Gradle dependencies
-        uses: amulya-labs/gha-opencache@v2
+        uses: amulya-labs/gha-opencache@v3
         with:
           path: ~/.gradle/caches
           key: gradle-${{ hashFiles('**/*.gradle*') }}
@@ -128,7 +128,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Cache pip packages
-        uses: amulya-labs/gha-opencache@v2
+        uses: amulya-labs/gha-opencache@v3
         with:
           path: ~/.cache/pip
           # Separate cache per Python version

--- a/examples/fail-on-cache-miss.yml
+++ b/examples/fail-on-cache-miss.yml
@@ -42,7 +42,7 @@ jobs:
           node-version: '20'
 
       - name: Cache dependencies
-        uses: amulya-labs/gha-opencache@v2
+        uses: amulya-labs/gha-opencache@v3
         with:
           path: node_modules
           key: deps-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
@@ -55,7 +55,7 @@ jobs:
           npm run build
 
       - name: Cache build artifacts
-        uses: amulya-labs/gha-opencache@v2
+        uses: amulya-labs/gha-opencache@v3
         with:
           path: dist/
           key: build-${{ github.sha }}
@@ -71,7 +71,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Restore build artifacts (REQUIRED)
-        uses: amulya-labs/gha-opencache@v2
+        uses: amulya-labs/gha-opencache@v3
         with:
           path: dist/
           key: build-${{ github.sha }}
@@ -96,7 +96,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Restore build artifacts (REQUIRED)
-        uses: amulya-labs/gha-opencache@v2
+        uses: amulya-labs/gha-opencache@v3
         with:
           path: dist/
           key: build-${{ github.sha }}

--- a/examples/gcs-basic.yml
+++ b/examples/gcs-basic.yml
@@ -41,7 +41,7 @@ jobs:
       # Cache node_modules using GCS
       - name: Cache npm dependencies
         id: cache
-        uses: amulya-labs/gha-opencache@v2
+        uses: amulya-labs/gha-opencache@v3
         with:
           path: node_modules
           key: npm-${{ runner.os }}-${{ hashFiles('package-lock.json') }}

--- a/examples/gcs-workload-identity.yml
+++ b/examples/gcs-workload-identity.yml
@@ -52,7 +52,7 @@ jobs:
       # Cache node_modules using GCS with Workload Identity
       - name: Cache npm dependencies
         id: cache
-        uses: amulya-labs/gha-opencache@v2
+        uses: amulya-labs/gha-opencache@v3
         with:
           path: node_modules
           key: npm-${{ runner.os }}-${{ hashFiles('package-lock.json') }}

--- a/examples/go-modules.yml
+++ b/examples/go-modules.yml
@@ -37,7 +37,7 @@ jobs:
           go-version: '1.21'
 
       - name: Cache Go modules
-        uses: amulya-labs/gha-opencache@v2
+        uses: amulya-labs/gha-opencache@v3
         with:
           path: ~/go/pkg/mod
           # Primary key: exact match on go.sum
@@ -49,7 +49,7 @@ jobs:
             go-mod-${{ runner.os }}-
 
       - name: Cache Go build artifacts
-        uses: amulya-labs/gha-opencache@v2
+        uses: amulya-labs/gha-opencache@v3
         with:
           path: ~/.cache/go-build
           # Primary key: exact match on all Go source files

--- a/examples/lookup-only.yml
+++ b/examples/lookup-only.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Check if cache exists (lookup only)
         id: cache-check
-        uses: amulya-labs/gha-opencache@v2
+        uses: amulya-labs/gha-opencache@v3
         with:
           path: node_modules
           key: deps-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
@@ -72,7 +72,7 @@ jobs:
       # Actual cache restore (downloads the cache)
       - name: Restore cache
         if: needs.check-cache.outputs.cache-hit == 'true'
-        uses: amulya-labs/gha-opencache@v2
+        uses: amulya-labs/gha-opencache@v3
         with:
           path: node_modules
           key: deps-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
@@ -105,7 +105,7 @@ jobs:
       # Check all matrix caches in parallel (fast)
       - name: Check Node 20 cache
         id: check-20
-        uses: amulya-labs/gha-opencache@v2
+        uses: amulya-labs/gha-opencache@v3
         with:
           path: node_modules
           key: deps-node20-${{ hashFiles('package-lock.json') }}
@@ -113,7 +113,7 @@ jobs:
 
       - name: Check Node 18 cache
         id: check-18
-        uses: amulya-labs/gha-opencache@v2
+        uses: amulya-labs/gha-opencache@v3
         with:
           path: node_modules
           key: deps-node18-${{ hashFiles('package-lock.json') }}
@@ -135,7 +135,7 @@ jobs:
           node-version: ${{ matrix.node }}
 
       - name: Restore cache
-        uses: amulya-labs/gha-opencache@v2
+        uses: amulya-labs/gha-opencache@v3
         with:
           path: node_modules
           key: deps-node${{ matrix.node }}-${{ hashFiles('package-lock.json') }}

--- a/examples/multi-cache.yml
+++ b/examples/multi-cache.yml
@@ -33,7 +33,7 @@ jobs:
 
       # Cache 1: npm dependencies (changes infrequently)
       - name: Cache npm dependencies
-        uses: amulya-labs/gha-opencache@v2
+        uses: amulya-labs/gha-opencache@v3
         with:
           path: node_modules
           key: deps-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
@@ -41,7 +41,7 @@ jobs:
 
       # Cache 2: Build artifacts (changes frequently)
       - name: Cache build output
-        uses: amulya-labs/gha-opencache@v2
+        uses: amulya-labs/gha-opencache@v3
         with:
           path: dist
           key: build-${{ runner.os }}-${{ github.sha }}
@@ -51,7 +51,7 @@ jobs:
 
       # Cache 3: Test coverage (per branch)
       - name: Cache coverage
-        uses: amulya-labs/gha-opencache@v2
+        uses: amulya-labs/gha-opencache@v3
         with:
           path: coverage
           key: coverage-${{ github.ref }}-${{ github.sha }}

--- a/examples/node-basic.yml
+++ b/examples/node-basic.yml
@@ -32,7 +32,7 @@ jobs:
           node-version: '20'
 
       - name: Cache npm dependencies
-        uses: amulya-labs/gha-opencache@v2
+        uses: amulya-labs/gha-opencache@v3
         with:
           path: node_modules
           # Primary key: exact match on package-lock.json

--- a/examples/python-pip.yml
+++ b/examples/python-pip.yml
@@ -37,7 +37,7 @@ jobs:
           python-version: '3.11'
 
       - name: Cache pip packages
-        uses: amulya-labs/gha-opencache@v2
+        uses: amulya-labs/gha-opencache@v3
         with:
           path: ~/.cache/pip
           # Primary key: exact match on requirements.txt

--- a/examples/restore-keys-advanced.yml
+++ b/examples/restore-keys-advanced.yml
@@ -34,7 +34,7 @@ jobs:
           node-version: '20'
 
       - name: Cache with branch hierarchy
-        uses: amulya-labs/gha-opencache@v2
+        uses: amulya-labs/gha-opencache@v3
         with:
           path: node_modules
           # Primary: exact match for this branch + lockfile
@@ -76,7 +76,7 @@ jobs:
           node-version: '20'
 
       - name: Cache root dependencies
-        uses: amulya-labs/gha-opencache@v2
+        uses: amulya-labs/gha-opencache@v3
         with:
           path: node_modules
           key: root-deps-${{ hashFiles('package-lock.json') }}
@@ -84,7 +84,7 @@ jobs:
             root-deps-
 
       - name: Cache workspace A
-        uses: amulya-labs/gha-opencache@v2
+        uses: amulya-labs/gha-opencache@v3
         with:
           path: packages/app-a/node_modules
           # Include both workspace and root lockfiles
@@ -94,7 +94,7 @@ jobs:
             workspace-a-
 
       - name: Cache workspace B
-        uses: amulya-labs/gha-opencache@v2
+        uses: amulya-labs/gha-opencache@v3
         with:
           path: packages/app-b/node_modules
           key: workspace-b-${{ hashFiles('packages/app-b/package.json', 'package-lock.json') }}
@@ -124,7 +124,7 @@ jobs:
           python-version: '3.11'
 
       - name: Cache with graceful dependency updates
-        uses: amulya-labs/gha-opencache@v2
+        uses: amulya-labs/gha-opencache@v3
         with:
           path: ~/.cache/pip
           # Primary: exact requirements.txt hash
@@ -160,7 +160,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Cache with platform fallback
-        uses: amulya-labs/gha-opencache@v2
+        uses: amulya-labs/gha-opencache@v3
         with:
           path: ~/.cargo
           # Primary: exact OS, arch, and lockfile
@@ -197,7 +197,7 @@ jobs:
         run: echo "number=$(date +%U)" >> "$GITHUB_OUTPUT"
 
       - name: Cache with weekly rotation
-        uses: amulya-labs/gha-opencache@v2
+        uses: amulya-labs/gha-opencache@v3
         with:
           path: ~/.npm
           # Primary: current week + lockfile

--- a/examples/rust-cargo.yml
+++ b/examples/rust-cargo.yml
@@ -30,21 +30,21 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache Cargo registry
-        uses: amulya-labs/gha-opencache@v2
+        uses: amulya-labs/gha-opencache@v3
         with:
           path: ~/.cargo/registry
           key: cargo-registry-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
           restore-keys: cargo-registry-${{ runner.os }}-
 
       - name: Cache Cargo index
-        uses: amulya-labs/gha-opencache@v2
+        uses: amulya-labs/gha-opencache@v3
         with:
           path: ~/.cargo/git
           key: cargo-git-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
           restore-keys: cargo-git-${{ runner.os }}-
 
       - name: Cache build artifacts
-        uses: amulya-labs/gha-opencache@v2
+        uses: amulya-labs/gha-opencache@v3
         with:
           path: target
           key: cargo-build-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}

--- a/examples/s3-cloudflare-r2.yml
+++ b/examples/s3-cloudflare-r2.yml
@@ -32,7 +32,7 @@ jobs:
           node-version: '20'
 
       - name: Cache with Cloudflare R2
-        uses: amulya-labs/gha-opencache@v2
+        uses: amulya-labs/gha-opencache@v3
         with:
           path: |
             node_modules

--- a/examples/s3-minio.yml
+++ b/examples/s3-minio.yml
@@ -32,7 +32,7 @@ jobs:
           node-version: '20'
 
       - name: Cache with MinIO
-        uses: amulya-labs/gha-opencache@v2
+        uses: amulya-labs/gha-opencache@v3
         with:
           path: node_modules
           key: npm-${{ runner.os }}-${{ hashFiles('package-lock.json') }}

--- a/examples/save-always.yml
+++ b/examples/save-always.yml
@@ -40,7 +40,7 @@ jobs:
 
       # === INCREMENTAL COMPILATION CACHE ===
       - name: Cache Rust build artifacts (save always)
-        uses: amulya-labs/gha-opencache@v2
+        uses: amulya-labs/gha-opencache@v3
         with:
           path: |
             ~/.cargo/registry
@@ -76,7 +76,7 @@ jobs:
 
       # === TEST COVERAGE CACHE ===
       - name: Cache test coverage (save always)
-        uses: amulya-labs/gha-opencache@v2
+        uses: amulya-labs/gha-opencache@v3
         with:
           path: coverage/
           key: coverage-${{ runner.os }}-${{ github.sha }}

--- a/examples/ttl-and-eviction.yml
+++ b/examples/ttl-and-eviction.yml
@@ -33,7 +33,7 @@ jobs:
           node-version: '20'
 
       - name: Cache with TTL and size limits
-        uses: amulya-labs/gha-opencache@v2
+        uses: amulya-labs/gha-opencache@v3
         with:
           path: node_modules
           key: npm-${{ runner.os }}-${{ hashFiles('package-lock.json') }}


### PR DESCRIPTION
## Summary
- Update version references from v2 to v3 following the major version bump
- v2 floating tag was corrupted by an accidental release; moved to v3

## Changes
- Example version: `2.0.0` → `3.0.0`
- Floating tag example: `v2 → v2.2.3` → `v3 → v3.0.1`
- User reference: `@v2` → `@v3`

🤖 Generated with [Claude Code](https://claude.com/claude-code)