### PR TITLE
fix: Use PAT for release publish to trigger publish.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -155,7 +155,10 @@ jobs:
 
       - name: Publish release
         env:
-          GH_TOKEN: ${{ github.token }}
+          # Use PAT instead of GITHUB_TOKEN to ensure release:published event
+          # triggers the publish.yml workflow. GITHUB_TOKEN suppresses events
+          # to prevent recursive workflow runs.
+          GH_TOKEN: ${{ secrets.PUBLIC_REPO_WRITE_PAT }}
           GH_REPO: ${{ github.repository }}
         run: |
           # Publish the release (makes it non-draft)


### PR DESCRIPTION
## Summary

Fix the `publish.yml` workflow not triggering on `release:published` events.

## Root Cause

`GITHUB_TOKEN` suppresses workflow events to prevent recursive runs. When `release.yml` used `github.token` to publish the release via `gh release edit --draft=false`, the `release:published` event was suppressed and `publish.yml` never triggered.

## Solution

Use `PUBLIC_REPO_WRITE_PAT` (already configured for floating tag updates) to publish the release. Events from PAT-authenticated actions propagate normally.

## Testing

Verified with prerelease `v3.0.4-rc.1`:
- Before fix: `publish.yml` had **0 runs** across v3.0.2 and v3.0.3 releases
- After fix: `publish.yml` **triggered successfully** via `release` event

## References

- [GitHub Community: Release publish not triggering workflow](https://github.com/orgs/community/discussions/54574)
- [GitHub Community: Releases by github-actions won't fire events](https://github.com/orgs/community/discussions/16244)

🤖 Generated with [Claude Code](https://claude.com/claude-code)