### PR TITLE
feat: UID-namespaced local cache paths with startup write-access check

### DIFF
--- a/__tests__/integration/cache.test.ts
+++ b/__tests__/integration/cache.test.ts
@@ -305,7 +305,8 @@ describe('LocalStorageProvider integration', () => {
 
   describe('index migration', () => {
     it('migrates v1 index to v2 on load', async () => {
-      const repoDir = path.join(cacheDir, 'test-owner', 'migrate-repo');
+      const uid = process.getuid?.() ?? 0;
+      const repoDir = path.join(cacheDir, `uid-${uid}`, 'test-owner', 'migrate-repo');
       fs.mkdirSync(path.join(repoDir, 'archives'), { recursive: true });
       fs.writeFileSync(path.join(repoDir, 'archives', 'test.tar.gz'), 'dummy');
 

--- a/__tests__/integration/rebuild.test.ts
+++ b/__tests__/integration/rebuild.test.ts
@@ -23,7 +23,8 @@ describe('Index Rebuild Integration', () => {
   beforeEach(async () => {
     // Create unique test directory
     testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'opencache-rebuild-test-'));
-    cacheDir = path.join(testDir, 'owner', 'repo');
+    const uid = process.getuid?.() ?? 0;
+    cacheDir = path.join(testDir, `uid-${uid}`, 'owner', 'repo');
     archivesDir = path.join(cacheDir, ARCHIVES_DIR);
 
     // Ensure directories exist

--- a/__tests__/unit/storage/fileLockManager.test.ts
+++ b/__tests__/unit/storage/fileLockManager.test.ts
@@ -1,0 +1,77 @@
+jest.mock('proper-lockfile');
+jest.mock('fs');
+jest.mock('@actions/io', () => ({
+  mkdirP: jest.fn().mockResolvedValue(undefined),
+}));
+
+import * as lockfile from 'proper-lockfile';
+import { existsSync, writeFileSync } from 'fs';
+import { FileLockManager } from '../../../src/storage/local/fileLockManager';
+
+describe('FileLockManager', () => {
+  const lockPath = '/srv/gha-cache/praxiom-systems/stock-trading/index.json.lock';
+  const mockLockfile = lockfile as jest.Mocked<typeof lockfile>;
+  const mockExistsSync = existsSync as jest.MockedFunction<typeof existsSync>;
+  const mockWriteFileSync = writeFileSync as jest.MockedFunction<typeof writeFileSync>;
+  let mockRelease: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockRelease = jest.fn().mockResolvedValue(undefined);
+    mockExistsSync.mockReturnValue(true);
+    mockWriteFileSync.mockReturnValue(undefined);
+    mockLockfile.lock.mockResolvedValue(mockRelease);
+  });
+
+  describe('withLock', () => {
+    it('executes function and returns result', async () => {
+      const manager = new FileLockManager(lockPath);
+      const result = await manager.withLock(() => Promise.resolve('ok'));
+      expect(result).toBe('ok');
+    });
+
+    it('releases lock after function completes', async () => {
+      const manager = new FileLockManager(lockPath);
+      await manager.withLock(() => Promise.resolve());
+      expect(mockRelease).toHaveBeenCalledTimes(1);
+    });
+
+    it('releases lock even if function throws', async () => {
+      mockLockfile.lock.mockResolvedValue(mockRelease);
+      const manager = new FileLockManager(lockPath);
+      await expect(manager.withLock(() => Promise.reject(new Error('fn error')))).rejects.toThrow(
+        'fn error'
+      );
+      expect(mockRelease).toHaveBeenCalledTimes(1);
+    });
+
+    it('throws helpful error with fix instructions when lock acquisition is permission denied', async () => {
+      const eaccesError = Object.assign(
+        new Error('EACCES: permission denied, mkdir \'/srv/gha-cache/praxiom-systems/stock-trading/index.json.lock.lock\''),
+        { code: 'EACCES' }
+      );
+      mockLockfile.lock.mockRejectedValue(eaccesError);
+      const manager = new FileLockManager(lockPath);
+
+      await expect(manager.withLock(() => Promise.resolve())).rejects.toThrow(
+        /Permission denied.*lock.*\/srv\/gha-cache\/praxiom-systems\/stock-trading/s
+      );
+    });
+
+    it('error message for EACCES includes chown fix instructions', async () => {
+      const eaccesError = Object.assign(new Error('EACCES: permission denied'), { code: 'EACCES' });
+      mockLockfile.lock.mockRejectedValue(eaccesError);
+      const manager = new FileLockManager(lockPath);
+
+      await expect(manager.withLock(() => Promise.resolve())).rejects.toThrow(/chown/);
+    });
+
+    it('propagates non-permission errors unchanged', async () => {
+      const otherError = new Error('Lock already held');
+      mockLockfile.lock.mockRejectedValue(otherError);
+      const manager = new FileLockManager(lockPath);
+
+      await expect(manager.withLock(() => Promise.resolve())).rejects.toThrow('Lock already held');
+    });
+  });
+});

--- a/__tests__/unit/storage/fileLockManager.test.ts
+++ b/__tests__/unit/storage/fileLockManager.test.ts
@@ -60,12 +60,13 @@ describe('FileLockManager', () => {
       );
     });
 
-    it('error message for EACCES includes chown fix instructions', async () => {
+    it('error message for EACCES includes platform-appropriate fix instructions', async () => {
       const eaccesError = Object.assign(new Error('EACCES: permission denied'), { code: 'EACCES' });
       mockLockfile.lock.mockRejectedValue(eaccesError);
       const manager = new FileLockManager(lockPath);
 
-      await expect(manager.withLock(() => Promise.resolve())).rejects.toThrow(/chown/);
+      const fixPattern = process.platform === 'win32' ? /icacls.*\/grant/ : /chown/;
+      await expect(manager.withLock(() => Promise.resolve())).rejects.toThrow(fixPattern);
     });
 
     it('propagates non-permission errors unchanged', async () => {

--- a/__tests__/unit/storage/fileLockManager.test.ts
+++ b/__tests__/unit/storage/fileLockManager.test.ts
@@ -47,7 +47,9 @@ describe('FileLockManager', () => {
 
     it('throws helpful error with fix instructions when lock acquisition is permission denied', async () => {
       const eaccesError = Object.assign(
-        new Error('EACCES: permission denied, mkdir \'/srv/gha-cache/praxiom-systems/stock-trading/index.json.lock.lock\''),
+        new Error(
+          "EACCES: permission denied, mkdir '/srv/gha-cache/praxiom-systems/stock-trading/index.json.lock.lock'"
+        ),
         { code: 'EACCES' }
       );
       mockLockfile.lock.mockRejectedValue(eaccesError);

--- a/__tests__/unit/storage/localProvider.test.ts
+++ b/__tests__/unit/storage/localProvider.test.ts
@@ -100,11 +100,12 @@ describe('LocalStorageProvider', () => {
         throw eaccesError;
       });
 
+      const fixPattern = process.platform === 'win32' ? /icacls.*\/grant/ : /chown.*\$\(whoami\)/;
       expect(() => createLocalStorageProvider('/srv/gha-cache', 'owner', 'repo')).toThrow(
         /Cannot write to cache base directory: \/srv\/gha-cache/
       );
       expect(() => createLocalStorageProvider('/srv/gha-cache', 'owner', 'repo')).toThrow(
-        /chown.*\$\(whoami\)/
+        fixPattern
       );
       expect(() => createLocalStorageProvider('/srv/gha-cache', 'owner', 'repo')).toThrow(
         /OPENCACHE_PATH/

--- a/__tests__/unit/storage/localProvider.test.ts
+++ b/__tests__/unit/storage/localProvider.test.ts
@@ -113,12 +113,15 @@ describe('LocalStorageProvider', () => {
 
     it('uses uid-0 on platforms without process.getuid', () => {
       const originalGetuid = process.getuid;
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore simulating Windows where getuid is undefined
-      process.getuid = undefined;
-      createLocalStorageProvider('/cache', 'owner', 'repo');
-      expect(mockCreateLocalStorageBackend).toHaveBeenCalledWith('/cache/uid-0/owner/repo');
-      process.getuid = originalGetuid;
+      try {
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore simulating Windows where getuid is undefined
+        process.getuid = undefined;
+        createLocalStorageProvider('/cache', 'owner', 'repo');
+        expect(mockCreateLocalStorageBackend).toHaveBeenCalledWith('/cache/uid-0/owner/repo');
+      } finally {
+        process.getuid = originalGetuid;
+      }
     });
   });
 

--- a/__tests__/unit/storage/localProvider.test.ts
+++ b/__tests__/unit/storage/localProvider.test.ts
@@ -102,6 +102,24 @@ describe('LocalStorageProvider', () => {
 
       expect(provider).toBeInstanceOf(LocalStorageProvider);
     });
+
+    it('includes uid segment in cacheDir path', () => {
+      const uid = process.getuid?.() ?? 0;
+      createLocalStorageProvider('/cache', 'owner', 'repo');
+      expect(mockCreateLocalStorageBackend).toHaveBeenCalledWith(
+        `/cache/uid-${uid}/owner/repo`
+      );
+    });
+
+    it('uses uid-0 on platforms without process.getuid', () => {
+      const originalGetuid = process.getuid;
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore simulating Windows where getuid is undefined
+      process.getuid = undefined;
+      createLocalStorageProvider('/cache', 'owner', 'repo');
+      expect(mockCreateLocalStorageBackend).toHaveBeenCalledWith('/cache/uid-0/owner/repo');
+      process.getuid = originalGetuid;
+    });
   });
 
   describe('restore', () => {

--- a/__tests__/unit/storage/localProvider.test.ts
+++ b/__tests__/unit/storage/localProvider.test.ts
@@ -87,6 +87,57 @@ describe('LocalStorageProvider', () => {
     jest.clearAllMocks();
   });
 
+  describe('startup write-access check', () => {
+    beforeEach(() => {
+      mockFs.existsSync.mockReturnValue(false);
+      mockFs.accessSync.mockReturnValue(undefined);
+    });
+
+    it('throws clear error with path when basePath exists but is not writable', () => {
+      mockFs.existsSync.mockReturnValue(true);
+      const eaccesError = Object.assign(new Error('EACCES'), { code: 'EACCES' });
+      mockFs.accessSync.mockImplementation(() => { throw eaccesError; });
+
+      expect(() => createLocalStorageProvider('/srv/gha-cache', 'owner', 'repo')).toThrow(
+        /Cannot write to cache base directory: \/srv\/gha-cache/
+      );
+    });
+
+    it('error includes chmod and chgrp fix commands', () => {
+      mockFs.existsSync.mockReturnValue(true);
+      const eaccesError = Object.assign(new Error('EACCES'), { code: 'EACCES' });
+      mockFs.accessSync.mockImplementation(() => { throw eaccesError; });
+
+      expect(() => createLocalStorageProvider('/srv/gha-cache', 'owner', 'repo')).toThrow(
+        /chmod g\+w/
+      );
+    });
+
+    it('error includes OPENCACHE_PATH alternative', () => {
+      mockFs.existsSync.mockReturnValue(true);
+      const eaccesError = Object.assign(new Error('EACCES'), { code: 'EACCES' });
+      mockFs.accessSync.mockImplementation(() => { throw eaccesError; });
+
+      expect(() => createLocalStorageProvider('/srv/gha-cache', 'owner', 'repo')).toThrow(
+        /OPENCACHE_PATH/
+      );
+    });
+
+    it('does not throw when basePath exists and is writable', () => {
+      mockFs.existsSync.mockReturnValue(true);
+      mockFs.accessSync.mockReturnValue(undefined);
+
+      expect(() => createLocalStorageProvider('/srv/gha-cache', 'owner', 'repo')).not.toThrow();
+    });
+
+    it('does not check access when basePath does not exist', () => {
+      mockFs.existsSync.mockReturnValue(false);
+
+      expect(() => createLocalStorageProvider('/srv/gha-cache', 'owner', 'repo')).not.toThrow();
+      expect(mockFs.accessSync).not.toHaveBeenCalled();
+    });
+  });
+
   describe('createLocalStorageProvider', () => {
     it('creates provider', () => {
       const provider = createLocalStorageProvider('/cache', 'owner', 'repo');

--- a/__tests__/unit/storage/localProvider.test.ts
+++ b/__tests__/unit/storage/localProvider.test.ts
@@ -96,7 +96,9 @@ describe('LocalStorageProvider', () => {
     it('throws clear error with path and fix commands when basePath exists but is not writable', () => {
       mockFs.existsSync.mockReturnValue(true);
       const eaccesError = Object.assign(new Error('EACCES'), { code: 'EACCES' });
-      mockFs.accessSync.mockImplementation(() => { throw eaccesError; });
+      mockFs.accessSync.mockImplementation(() => {
+        throw eaccesError;
+      });
 
       expect(() => createLocalStorageProvider('/srv/gha-cache', 'owner', 'repo')).toThrow(
         /Cannot write to cache base directory: \/srv\/gha-cache/
@@ -112,7 +114,9 @@ describe('LocalStorageProvider', () => {
     it('also throws for EPERM errors', () => {
       mockFs.existsSync.mockReturnValue(true);
       const epermError = Object.assign(new Error('EPERM'), { code: 'EPERM' });
-      mockFs.accessSync.mockImplementation(() => { throw epermError; });
+      mockFs.accessSync.mockImplementation(() => {
+        throw epermError;
+      });
 
       expect(() => createLocalStorageProvider('/srv/gha-cache', 'owner', 'repo')).toThrow(
         /Cannot write to cache base directory/
@@ -122,9 +126,13 @@ describe('LocalStorageProvider', () => {
     it('rethrows non-permission errors unchanged', () => {
       mockFs.existsSync.mockReturnValue(true);
       const ioError = Object.assign(new Error('I/O error'), { code: 'EIO' });
-      mockFs.accessSync.mockImplementation(() => { throw ioError; });
+      mockFs.accessSync.mockImplementation(() => {
+        throw ioError;
+      });
 
-      expect(() => createLocalStorageProvider('/srv/gha-cache', 'owner', 'repo')).toThrow('I/O error');
+      expect(() => createLocalStorageProvider('/srv/gha-cache', 'owner', 'repo')).toThrow(
+        'I/O error'
+      );
       expect(() => createLocalStorageProvider('/srv/gha-cache', 'owner', 'repo')).not.toThrow(
         /Cannot write to cache base directory/
       );
@@ -164,9 +172,7 @@ describe('LocalStorageProvider', () => {
     it('includes uid segment in cacheDir path', () => {
       const uid = process.getuid?.() ?? 0;
       createLocalStorageProvider('/cache', 'owner', 'repo');
-      expect(mockCreateLocalStorageBackend).toHaveBeenCalledWith(
-        `/cache/uid-${uid}/owner/repo`
-      );
+      expect(mockCreateLocalStorageBackend).toHaveBeenCalledWith(`/cache/uid-${uid}/owner/repo`);
     });
 
     it('uses uid-0 on platforms without process.getuid', () => {

--- a/__tests__/unit/storage/localProvider.test.ts
+++ b/__tests__/unit/storage/localProvider.test.ts
@@ -93,7 +93,7 @@ describe('LocalStorageProvider', () => {
       mockFs.accessSync.mockReturnValue(undefined);
     });
 
-    it('throws clear error with path when basePath exists but is not writable', () => {
+    it('throws clear error with path and fix commands when basePath exists but is not writable', () => {
       mockFs.existsSync.mockReturnValue(true);
       const eaccesError = Object.assign(new Error('EACCES'), { code: 'EACCES' });
       mockFs.accessSync.mockImplementation(() => { throw eaccesError; });
@@ -101,25 +101,32 @@ describe('LocalStorageProvider', () => {
       expect(() => createLocalStorageProvider('/srv/gha-cache', 'owner', 'repo')).toThrow(
         /Cannot write to cache base directory: \/srv\/gha-cache/
       );
-    });
-
-    it('error includes chmod and chgrp fix commands', () => {
-      mockFs.existsSync.mockReturnValue(true);
-      const eaccesError = Object.assign(new Error('EACCES'), { code: 'EACCES' });
-      mockFs.accessSync.mockImplementation(() => { throw eaccesError; });
-
       expect(() => createLocalStorageProvider('/srv/gha-cache', 'owner', 'repo')).toThrow(
-        /chmod g\+w/
+        /chown.*\$\(whoami\)/
+      );
+      expect(() => createLocalStorageProvider('/srv/gha-cache', 'owner', 'repo')).toThrow(
+        /OPENCACHE_PATH/
       );
     });
 
-    it('error includes OPENCACHE_PATH alternative', () => {
+    it('also throws for EPERM errors', () => {
       mockFs.existsSync.mockReturnValue(true);
-      const eaccesError = Object.assign(new Error('EACCES'), { code: 'EACCES' });
-      mockFs.accessSync.mockImplementation(() => { throw eaccesError; });
+      const epermError = Object.assign(new Error('EPERM'), { code: 'EPERM' });
+      mockFs.accessSync.mockImplementation(() => { throw epermError; });
 
       expect(() => createLocalStorageProvider('/srv/gha-cache', 'owner', 'repo')).toThrow(
-        /OPENCACHE_PATH/
+        /Cannot write to cache base directory/
+      );
+    });
+
+    it('rethrows non-permission errors unchanged', () => {
+      mockFs.existsSync.mockReturnValue(true);
+      const ioError = Object.assign(new Error('I/O error'), { code: 'EIO' });
+      mockFs.accessSync.mockImplementation(() => { throw ioError; });
+
+      expect(() => createLocalStorageProvider('/srv/gha-cache', 'owner', 'repo')).toThrow('I/O error');
+      expect(() => createLocalStorageProvider('/srv/gha-cache', 'owner', 'repo')).not.toThrow(
+        /Cannot write to cache base directory/
       );
     });
 

--- a/src/storage/local/fileLockManager.ts
+++ b/src/storage/local/fileLockManager.ts
@@ -32,14 +32,21 @@ export class FileLockManager implements LockManager {
     } catch (err) {
       const error = err as NodeJS.ErrnoException;
       if (error.code === 'EACCES' || error.code === 'EPERM') {
+        const isWin = process.platform === 'win32';
+        const fixCmd = isWin
+          ? `icacls "${dir}" /grant %USERNAME%:W`
+          : `sudo chown -R $(whoami) "${dir}"`;
+        const envCmd = isWin
+          ? 'set OPENCACHE_PATH=/path/with/write/access'
+          : 'export OPENCACHE_PATH=/path/with/write/access';
         throw new Error(
           `Permission denied acquiring lock at ${this.lockPath}\n\n` +
             `The cache directory exists but is not writable by the current user.\n` +
             `This can happen if a different user (e.g. root in a container) created it.\n\n` +
             `Fix — run once on your runner host:\n` +
-            `  sudo chown -R $(whoami) ${dir}\n\n` +
+            `  ${fixCmd}\n\n` +
             `Or point to a directory the runner user already owns:\n` +
-            `  export OPENCACHE_PATH=/home/runner/.cache/gha-opencache`
+            `  ${envCmd}`
         );
       }
       throw err;

--- a/src/storage/local/fileLockManager.ts
+++ b/src/storage/local/fileLockManager.ts
@@ -34,12 +34,12 @@ export class FileLockManager implements LockManager {
       if (error.code === 'EACCES' || error.code === 'EPERM') {
         throw new Error(
           `Permission denied acquiring lock at ${this.lockPath}\n\n` +
-          `The cache directory exists but is not writable by the current user.\n` +
-          `This can happen if a different user (e.g. root in a container) created it.\n\n` +
-          `Fix — run once on your runner host:\n` +
-          `  sudo chown -R $(whoami) ${dir}\n\n` +
-          `Or point to a directory the runner user already owns:\n` +
-          `  export OPENCACHE_PATH=/home/runner/.cache/gha-opencache`
+            `The cache directory exists but is not writable by the current user.\n` +
+            `This can happen if a different user (e.g. root in a container) created it.\n\n` +
+            `Fix — run once on your runner host:\n` +
+            `  sudo chown -R $(whoami) ${dir}\n\n` +
+            `Or point to a directory the runner user already owns:\n` +
+            `  export OPENCACHE_PATH=/home/runner/.cache/gha-opencache`
         );
       }
       throw err;

--- a/src/storage/local/fileLockManager.ts
+++ b/src/storage/local/fileLockManager.ts
@@ -26,7 +26,23 @@ export class FileLockManager implements LockManager {
       fs.writeFileSync(this.lockPath, '');
     }
 
-    const release = await lockfile.lock(this.lockPath, LOCK_OPTIONS);
+    let release: () => Promise<void>;
+    try {
+      release = await lockfile.lock(this.lockPath, LOCK_OPTIONS);
+    } catch (err) {
+      const error = err as NodeJS.ErrnoException;
+      if (error.code === 'EACCES' || error.code === 'EPERM') {
+        const dir = path.dirname(this.lockPath);
+        throw new Error(
+          `Permission denied acquiring lock at ${this.lockPath}\n\n` +
+            `To fix this, run on your runner host:\n` +
+            `  sudo chown -R $(whoami) ${dir}\n\n` +
+            `Or set OPENCACHE_PATH to a directory the runner user can write to:\n` +
+            `  export OPENCACHE_PATH=/path/with/write/access`
+        );
+      }
+      throw err;
+    }
 
     try {
       return await fn();

--- a/src/storage/local/fileLockManager.ts
+++ b/src/storage/local/fileLockManager.ts
@@ -35,10 +35,12 @@ export class FileLockManager implements LockManager {
         const dir = path.dirname(this.lockPath);
         throw new Error(
           `Permission denied acquiring lock at ${this.lockPath}\n\n` +
-            `To fix this, run on your runner host:\n` +
-            `  sudo chown -R $(whoami) ${dir}\n\n` +
-            `Or set OPENCACHE_PATH to a directory the runner user can write to:\n` +
-            `  export OPENCACHE_PATH=/path/with/write/access`
+          `The cache directory exists but is not writable by the current user.\n` +
+          `This can happen if a different user (e.g. root in a container) created it.\n\n` +
+          `Fix — run once on your runner host:\n` +
+          `  sudo chown -R $(whoami) ${dir}\n\n` +
+          `Or point to a directory the runner user already owns:\n` +
+          `  export OPENCACHE_PATH=/home/runner/.cache/gha-opencache`
         );
       }
       throw err;

--- a/src/storage/local/fileLockManager.ts
+++ b/src/storage/local/fileLockManager.ts
@@ -32,7 +32,6 @@ export class FileLockManager implements LockManager {
     } catch (err) {
       const error = err as NodeJS.ErrnoException;
       if (error.code === 'EACCES' || error.code === 'EPERM') {
-        const dir = path.dirname(this.lockPath);
         throw new Error(
           `Permission denied acquiring lock at ${this.lockPath}\n\n` +
           `The cache directory exists but is not writable by the current user.\n` +

--- a/src/storage/local/localProvider.ts
+++ b/src/storage/local/localProvider.ts
@@ -18,14 +18,21 @@ function checkBaseDirWritable(basePath: string): void {
   } catch (err) {
     const error = err as NodeJS.ErrnoException;
     if (error.code === 'EACCES' || error.code === 'EPERM') {
+      const isWin = process.platform === 'win32';
+      const fixCmd = isWin
+        ? `icacls "${basePath}" /grant %USERNAME%:W`
+        : `sudo chown -R $(whoami) "${basePath}"`;
+      const envCmd = isWin
+        ? 'set OPENCACHE_PATH=/path/with/write/access'
+        : 'export OPENCACHE_PATH=/path/with/write/access';
       throw new Error(
         `Cannot write to cache base directory: ${basePath}\n\n` +
           `This usually means a container job (running as root) previously created\n` +
           `this directory, and a non-container job is now trying to use it.\n\n` +
           `Fix — run once on your runner host:\n` +
-          `  sudo chown -R $(whoami) ${basePath}\n\n` +
+          `  ${fixCmd}\n\n` +
           `Or point to a directory the runner user already owns:\n` +
-          `  export OPENCACHE_PATH=/home/runner/.cache/gha-opencache`
+          `  ${envCmd}`
       );
     }
     throw err;

--- a/src/storage/local/localProvider.ts
+++ b/src/storage/local/localProvider.ts
@@ -20,12 +20,12 @@ function checkBaseDirWritable(basePath: string): void {
     if (error.code === 'EACCES' || error.code === 'EPERM') {
       throw new Error(
         `Cannot write to cache base directory: ${basePath}\n\n` +
-        `This usually means a container job (running as root) previously created\n` +
-        `this directory, and a non-container job is now trying to use it.\n\n` +
-        `Fix — run once on your runner host:\n` +
-        `  sudo chown -R $(whoami) ${basePath}\n\n` +
-        `Or point to a directory the runner user already owns:\n` +
-        `  export OPENCACHE_PATH=/home/runner/.cache/gha-opencache`
+          `This usually means a container job (running as root) previously created\n` +
+          `this directory, and a non-container job is now trying to use it.\n\n` +
+          `Fix — run once on your runner host:\n` +
+          `  sudo chown -R $(whoami) ${basePath}\n\n` +
+          `Or point to a directory the runner user already owns:\n` +
+          `  export OPENCACHE_PATH=/home/runner/.cache/gha-opencache`
       );
     }
     throw err;

--- a/src/storage/local/localProvider.ts
+++ b/src/storage/local/localProvider.ts
@@ -27,7 +27,8 @@ export class LocalStorageProvider extends BaseStorageProvider implements Storage
   private readonly localBackend: LocalStorageBackend;
 
   constructor(basePath: string, owner: string, repo: string, options: LocalStorageOptions = {}) {
-    const cacheDir = path.join(basePath, owner, repo);
+    const uid = process.getuid?.() ?? 0;
+    const cacheDir = path.join(basePath, `uid-${uid}`, owner, repo);
     const localBackend = createLocalStorageBackend(cacheDir);
     const indexStore = createFileIndexStore(cacheDir);
     const lockManager = createFileLockManager(cacheDir);

--- a/src/storage/local/localProvider.ts
+++ b/src/storage/local/localProvider.ts
@@ -11,6 +11,28 @@ import { createArchive, extractArchive } from '../../archive/tar';
 import { CompressionOptions } from '../../archive/compression';
 import { entryToManifest, writeManifest, deleteManifest } from './manifestStore';
 
+function checkBaseDirWritable(basePath: string): void {
+  if (!fs.existsSync(basePath)) return;
+  try {
+    fs.accessSync(basePath, fs.constants.W_OK);
+  } catch (err) {
+    const error = err as NodeJS.ErrnoException;
+    if (error.code === 'EACCES' || error.code === 'EPERM') {
+      throw new Error(
+        `Cannot write to cache base directory: ${basePath}\n\n` +
+        `This usually means a container job (running as root) previously created\n` +
+        `this directory, and a non-container job is now trying to use it.\n\n` +
+        `Fix — run once on your runner host:\n` +
+        `  sudo chmod g+w ${basePath}\n` +
+        `  sudo chgrp $(id -gn) ${basePath}\n\n` +
+        `Or point to a directory the runner user already owns:\n` +
+        `  export OPENCACHE_PATH=/home/runner/.cache/gha-opencache`
+      );
+    }
+    throw err;
+  }
+}
+
 /**
  * Options for local storage provider
  */
@@ -27,6 +49,8 @@ export class LocalStorageProvider extends BaseStorageProvider implements Storage
   private readonly localBackend: LocalStorageBackend;
 
   constructor(basePath: string, owner: string, repo: string, options: LocalStorageOptions = {}) {
+    checkBaseDirWritable(basePath);
+
     const uid = process.getuid?.() ?? 0;
     const cacheDir = path.join(basePath, `uid-${uid}`, owner, repo);
     const localBackend = createLocalStorageBackend(cacheDir);

--- a/src/storage/local/localProvider.ts
+++ b/src/storage/local/localProvider.ts
@@ -23,8 +23,7 @@ function checkBaseDirWritable(basePath: string): void {
         `This usually means a container job (running as root) previously created\n` +
         `this directory, and a non-container job is now trying to use it.\n\n` +
         `Fix — run once on your runner host:\n` +
-        `  sudo chmod g+w ${basePath}\n` +
-        `  sudo chgrp $(id -gn) ${basePath}\n\n` +
+        `  sudo chown -R $(whoami) ${basePath}\n\n` +
         `Or point to a directory the runner user already owns:\n` +
         `  export OPENCACHE_PATH=/home/runner/.cache/gha-opencache`
       );


### PR DESCRIPTION
## Summary

- Namespaces the local filesystem cache path by runner UID (`basePath/uid-{N}/owner/repo`) so container jobs (running as root) and bare-host jobs never share — or conflict over — the same cache directory
- Adds a startup check in `LocalStorageProvider` that detects when `basePath` exists but isn't writable, and fails immediately with a clear error and fix commands instead of a cryptic `EACCES` from deep inside `proper-lockfile`
- Aligns all EACCES error messages across `localProvider`, `fileLockManager`, and `fileIndexStore` to use the same `sudo chown -R $(whoami)` fix idiom

## Motivation

When a workflow has a Docker container job (runs as root, creates `/srv/gha-cache` owned by root) and a bare-host job (runs as e.g. `ci-docker`, uid 1003), the host job would hit:
```
Error: EACCES: permission denied, mkdir '.../index.json.lock.lock'
```
UID namespacing eliminates the conflict entirely. The startup check surfaces a root-cause explanation when the base directory isn't writable rather than a raw filesystem error.

## Error message (before → after)

**Before:**
```
Error: EACCES: permission denied, mkdir '/srv/gha-cache/praxiom-systems/stock-trading/index.json.lock.lock'
```

**After (startup check fires first):**
```
Cannot write to cache base directory: /srv/gha-cache

This usually means a container job (running as root) previously created
this directory, and a non-container job is now trying to use it.

Fix — run once on your runner host:
  sudo chown -R $(whoami) /srv/gha-cache

Or point to a directory the runner user already owns:
  export OPENCACHE_PATH=/home/runner/.cache/gha-opencache
```

## Breaking change

Existing caches at `basePath/owner/repo` are orphaned after upgrading — one cold-cache run, then they expire naturally via TTL. No migration needed.

## Test plan
- [ ] 573/573 tests pass (`npx jest --no-coverage`)
- [ ] On a runner with a root-owned `/srv/gha-cache`, the startup error message appears immediately on restore/save
- [ ] Container job (root) and host job (ci-docker) on the same runner no longer conflict

🤖 Generated with [Claude Code](https://claude.com/claude-code)